### PR TITLE
Trailing space is significant if alone

### DIFF
--- a/innerxhtml.js
+++ b/innerxhtml.js
@@ -28,7 +28,8 @@ innerXHTML = function($source) {
 				var $text_content = $children[$i].nodeValue;
 				$text_content = $text_content.replace(/</g,'&lt;');
 				$text_content = $text_content.replace(/>/g,'&gt;');
-				$text_content = $text_content.replace(/\s+$/,''); // trailing space not significant
+				if (!(/^\s+$/).test($text_content))
+				$text_content = $text_content.replace(/\s+$/,''); // trailing space not significant unless it is the only text content of the node
 				$xhtml += $text_content;
 			}
 			else if ($children[$i].nodeType == 8) {


### PR DESCRIPTION
I consider trailing space significant if it is the only text item in the node. Often this is used for pretty printing, which is lost if innerXHTML trims ALL trailing space.
